### PR TITLE
Add hourly scheduled trigger

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -35,7 +35,7 @@ module.exports.endpoint = async (event, context, callback) => {
 
     if (result[0].saved) {
         //If successful, upload files
-        console.log('uploading');
+        console.log('capture successful, now uploading to S3');
         const uploader = client.uploadDir(uploadParams);
 
         uploader.on('error', function(err) {

--- a/serverless.yml
+++ b/serverless.yml
@@ -37,3 +37,7 @@ functions:
           path: ping
           method: get
           private: true
+      - schedule:
+          name: page-capture-schedule
+          rate: rate(1 hour)
+          enabled: false


### PR DESCRIPTION
Creates a CloudWatch rule that triggers the page capture every hour.  It is disabled by default to allow for any final checks before enabling.