### PR TITLE
Prevent error uploads

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -3,6 +3,8 @@ const s3 = require('s3-node-client');
 const del = require('del');
 const Url = require('url-parse');
 
+const ValidatePlugin = require('./validatePlugin');
+
 const captureURL = new Url(process.env.CAPTURE_URL);
 
 // Allow for a prefix to the subdirectory, and add a slash if it is set.
@@ -20,6 +22,7 @@ const scrapeOptions = {
         {directory: `${subDirPrefix}css`, extensions: ['.css']},
         {directory: `${subDirPrefix}font`, extensions: ['.woff', '.woff2', '.ttf', '.eot']},
     ],
+    plugins: [ new ValidatePlugin() ],
 };
 
 const client = s3.createClient();

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=1.1.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   stage: prod
   region: us-east-1
   iamRoleStatements:

--- a/validatePlugin.js
+++ b/validatePlugin.js
@@ -1,0 +1,20 @@
+module.exports = class ValidatePlugin {
+    apply(registerAction) {
+        registerAction('error', async ({error}) => {console.error(error)});
+        registerAction('onResourceError', ({resource, error}) => console.log(`Resource ${resource.url} has error ${error}`));
+        registerAction('afterResponse', async ({response}) => {   
+            if (response.statusCode !== 200) {
+                // Don't capture bad assets.  Also cancels the upload phase if the root page has a bad status code.
+                console.log( `Bad status code ${response.statusCode} , cancelling asset capture` );
+                return null;
+            } else {
+                return {
+                    body: response.body,
+                    metadata: {
+                        headers: response.headers,
+                    }
+                };
+            }
+        });
+    }
+}


### PR DESCRIPTION
Checks the http status code of all responses, and drops capture if the response is anything but 200 (status OK).

If the root page capture is dropped, the result.saved property will be false and upload phase will be cancelled.

That means that if the underlying page target is returning an error, all uploads will be skipped and the existing files in S3 will remain as is.